### PR TITLE
Added functionality for named API

### DIFF
--- a/samples/ScryfallApi.WebSample/Pages/Named.cshtml
+++ b/samples/ScryfallApi.WebSample/Pages/Named.cshtml
@@ -1,0 +1,49 @@
+﻿@page
+@model NamedModel
+@{
+}
+
+<h2>Named</h2>
+<div class="row">
+  <div class="col-md-12">
+    <p>
+      Search Query:
+    </p>
+    <div asp-validation-summary="All"></div>
+    <form method="POST">
+      <div>
+        Name: <input asp-for="Query" />
+        <input type="submit" value="Search" />
+      </div>
+    </form>
+  </div>
+</div>
+@if (@Model?.NamedCard != null)
+{
+    <h3>Result: <a href="@Model.NamedCard.ScryfallUri">@Model.NamedCard.Name</a></h3>
+    <div class="row">
+      <div class="col-md-12">
+        <a href="@Model.NamedCard.ScryfallUri">
+          @if (Model.NamedCard.Layout.Equals("transform", StringComparison.OrdinalIgnoreCase))
+          {
+            foreach (var face in Model.NamedCard.CardFaces)
+            {
+              <img src="@face.ImageUris["normal"]" style="max-width: 320px;" />
+            }
+          }
+          else
+          {
+            <img src="@Model.NamedCard.ImageUris["normal"]" style="max-width: 320px;" />
+          }
+        </a>
+      </div>
+    </div>
+}
+else
+{
+  <div class="row">
+    <div class="col-sm-12">
+      <p>No cards found!</p>
+    </div>
+  </div>
+}

--- a/samples/ScryfallApi.WebSample/Pages/Named.cshtml.cs
+++ b/samples/ScryfallApi.WebSample/Pages/Named.cshtml.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using ScryfallApi.Client;
+using ScryfallApi.Client.Models;
+
+namespace ScryfallApi.WebSample.Pages
+{
+    public class NamedModel : PageModel
+    {
+        ScryfallApiClient _scryfallApi { get; }
+        public Card NamedCard { get; set; }
+
+        [BindProperty]
+        public string Query { get; set; }
+
+        public NamedModel(ScryfallApiClient scryfallApi)
+        {
+            _scryfallApi = scryfallApi ?? throw new ArgumentNullException(nameof(scryfallApi));
+        }
+
+        public void OnGet()
+        {
+        }
+
+        public async Task<ActionResult> OnPostAsync()
+        {
+            NamedCard = await _scryfallApi.Cards.Named(Query, true);
+            return Page();
+        }
+    }
+}

--- a/src/ScryfallApi.Client/Apis/Cards.cs
+++ b/src/ScryfallApi.Client/Apis/Cards.cs
@@ -19,6 +19,13 @@ public class Cards : ICards
 
     public Task<Card> GetRandom() => _restService.GetAsync<Card>($"/cards/random", false);
 
+    public Task<Card> Named(string cardname, bool fuzzySearch)
+    {
+        cardname = WebUtility.UrlEncode(cardname);
+        var searchType = fuzzySearch ? "fuzzy" : "exact";
+        return _restService.GetAsync<Card>($"/cards/named?{searchType}={cardname}");
+    }
+
     public Task<ResultList<Card>> Search(string query, int page, CardSort sort) =>
         Search(query, page, new SearchOptions { Sort = sort });
 
@@ -29,5 +36,6 @@ public class Cards : ICards
         query = WebUtility.UrlEncode(query);
         return _restService.GetAsync<ResultList<Card>>($"/cards/search?q={query}&page={page}&{options.BuildQueryString()}");
     }
+
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 }

--- a/src/ScryfallApi.Client/Apis/ICards.cs
+++ b/src/ScryfallApi.Client/Apis/ICards.cs
@@ -23,6 +23,14 @@ public interface ICards
     Task<ResultList<Card>> Get(int page);
 
     /// <summary>
+    /// Search for exactly one card of the given name. Search parameters can be either exact or fuzzy.
+    /// </summary>
+    /// <param name="cardname"></param>
+    /// <param name="fuzzySearch"></param>
+    /// <returns></returns>
+    Task<Card> Named(string cardname, bool fuzzySearch);
+
+    /// <summary>
     /// Search for cards with a sort option
     /// </summary>
     /// <param name="query"></param>
@@ -39,4 +47,5 @@ public interface ICards
     /// <param name="options"></param>
     /// <returns></returns>
     Task<ResultList<Card>> Search(string query, int page, SearchOptions options);
+
 }


### PR DESCRIPTION
This implements the [/named](https://scryfall.com/docs/api/cards/named) portion of the Scryfall API. It's useful for fast lookups of exactly one card.

I didn't implement some of the more specific filters that can be used on named and opted for just a boolean "fuzzy or exact" type search method. I also copied and implemented some components of the sample in order to test the changes.

Thanks!